### PR TITLE
Issue #5 fix

### DIFF
--- a/src/main/java/net/iryndin/jdbf/reader/DbfReader.java
+++ b/src/main/java/net/iryndin/jdbf/reader/DbfReader.java
@@ -9,11 +9,12 @@ import java.util.Arrays;
 
 public class DbfReader implements Closeable {
 
-    private ByteArrayInputStream dbfInputStream;
+    private InputStream dbfInputStream;
     private MemoReader memoReader;
     private DbfMetadata metadata;
     private byte[] oneRecordBuffer;
     private int recordsCounter = 0;
+    private static final int BUFFER_SIZE = 8192;
 
     public DbfReader(File dbfFile) throws IOException {
         this(new FileInputStream(dbfFile));
@@ -24,12 +25,12 @@ public class DbfReader implements Closeable {
     }
 
     public DbfReader(InputStream dbfInputStream) throws IOException {
-        this.dbfInputStream = new ByteArrayInputStream(IOUtils.toByteArray(dbfInputStream));
+        this.dbfInputStream = new BufferedInputStream(dbfInputStream, BUFFER_SIZE);
         readMetadata();
     }
 
     public DbfReader(InputStream dbfInputStream, InputStream memoInputStream) throws IOException {
-        this.dbfInputStream = new ByteArrayInputStream(IOUtils.toByteArray(dbfInputStream));
+        this.dbfInputStream = new BufferedInputStream(dbfInputStream, BUFFER_SIZE);
         this.memoReader = new MemoReader(memoInputStream);
         readMetadata();
     }
@@ -39,6 +40,7 @@ public class DbfReader implements Closeable {
     }
 
     private void readMetadata() throws IOException {
+        this.dbfInputStream.mark(1024*1024);
         metadata = new DbfMetadata();
         readHeader();
         DbfMetadataUtils.readFields(metadata, dbfInputStream);
@@ -77,7 +79,7 @@ public class DbfReader implements Closeable {
         seek(dbfInputStream, metadata.getFullHeaderLength());
     }
 
-    private void seek(ByteArrayInputStream inputStream, int position) {
+    private void seek(InputStream inputStream, int position) throws IOException {
         inputStream.reset();
         inputStream.skip(position);
     }

--- a/src/main/java/net/iryndin/jdbf/reader/MemoReader.java
+++ b/src/main/java/net/iryndin/jdbf/reader/MemoReader.java
@@ -21,7 +21,8 @@ import java.io.*;
  */
 public class MemoReader implements Closeable {
 
-    private ByteArrayInputStream memoInputStream;
+    private static final int BUFFER_SIZE = 8192;
+    private InputStream memoInputStream;
     private MemoFileHeader memoHeader;
 
     public MemoReader(File memoFile) throws IOException {
@@ -29,12 +30,13 @@ public class MemoReader implements Closeable {
     }
 
     public MemoReader(InputStream inputStream) throws IOException {
-        this.memoInputStream = new ByteArrayInputStream(IOUtils.toByteArray(inputStream));
+        this.memoInputStream = new BufferedInputStream(inputStream, BUFFER_SIZE);
         readMetadata();
     }
 
     private void readMetadata() throws IOException {
         byte[] headerBytes = new byte[JdbfUtils.MEMO_HEADER_LENGTH];
+        memoInputStream.mark(8192);
         memoInputStream.read(headerBytes);
         this.memoHeader = MemoFileHeader.create(headerBytes);
     }

--- a/src/main/java/net/iryndin/jdbf/util/DbfMetadataUtils.java
+++ b/src/main/java/net/iryndin/jdbf/util/DbfMetadataUtils.java
@@ -5,7 +5,7 @@ import net.iryndin.jdbf.core.DbfFieldTypeEnum;
 import net.iryndin.jdbf.core.DbfFileTypeEnum;
 import net.iryndin.jdbf.core.DbfMetadata;
 
-import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -74,7 +74,7 @@ public class DbfMetadataUtils {
 
     }
 
-    public static void readFields(DbfMetadata metadata, ByteArrayInputStream inputStream) throws IOException {
+    public static void readFields(DbfMetadata metadata, InputStream inputStream) throws IOException {
         List<DbfField> fields = new ArrayList<>();
         byte[] fieldBytes = new byte[JdbfUtils.FIELD_RECORD_LENGTH];
         int headerLength = 0;


### PR DESCRIPTION
Don't load DBF and MEMO files into memory when reading it.
Replaced ByteArrayInputStream by BufferedInputStream.

Tested on big foxpro table (700Mb).
