### PR TITLE
Issue 27b

### DIFF
--- a/src/main/java/net/iryndin/jdbf/reader/DbfReader.java
+++ b/src/main/java/net/iryndin/jdbf/reader/DbfReader.java
@@ -3,6 +3,7 @@ package net.iryndin.jdbf.reader;
 import net.iryndin.jdbf.core.*;
 import net.iryndin.jdbf.util.DbfMetadataUtils;
 import net.iryndin.jdbf.util.IOUtils;
+import sun.nio.ch.IOUtil;
 
 import java.io.*;
 import java.util.Arrays;
@@ -55,14 +56,14 @@ public class DbfReader implements Closeable {
         // 1. Allocate buffer
         byte[] bytes = new byte[HEADER_HALF_SIZE];
         // 2. Read 16 bytes
-        if (dbfInputStream.read(bytes) != HEADER_HALF_SIZE)
-        	throw new IOException("The file is corrupted or is not a dbf file");
-        	
+        if (IOUtils.readFully(dbfInputStream, bytes) != HEADER_HALF_SIZE)
+            throw new IOException("The file is corrupted or is not a dbf file");
+
         // 3. Fill header fields
         DbfMetadataUtils.fillHeaderFields(metadata, bytes);
         // 4. Read next 16 bytes (for most DBF types these are reserved bytes)
-        if (dbfInputStream.read(bytes) != HEADER_HALF_SIZE)
-        	throw new IOException("The file is corrupted or is not a dbf file");
+        if (IOUtils.readFully(dbfInputStream, bytes) != HEADER_HALF_SIZE)
+            throw new IOException("The file is corrupted or is not a dbf file");
     }
 
     @Override
@@ -90,7 +91,7 @@ public class DbfReader implements Closeable {
 
     public DbfRecord read() throws IOException {
         Arrays.fill(oneRecordBuffer, (byte)0x0);
-        int readLength = dbfInputStream.read(oneRecordBuffer);
+        int readLength = IOUtils.readFully(dbfInputStream, oneRecordBuffer);
 
         if (readLength < metadata.getOneRecordLength()) {
             return null;

--- a/src/main/java/net/iryndin/jdbf/util/DbfMetadataUtils.java
+++ b/src/main/java/net/iryndin/jdbf/util/DbfMetadataUtils.java
@@ -31,7 +31,7 @@ public class DbfMetadataUtils {
         return metadata;
     }
 
-    public static DbfMetadata fromFields(List<DbfField> fields, DbfFileTypeEnum fileType) {
+    public static DbfMetadata fromFields(List<DbfField> fields, DbfFileTypeEnum fileType) throws IOException {
         DbfMetadata metadata = new DbfMetadata();
 
         metadata.setType(fileType);

--- a/src/main/java/net/iryndin/jdbf/util/IOUtils.java
+++ b/src/main/java/net/iryndin/jdbf/util/IOUtils.java
@@ -22,4 +22,38 @@ public class IOUtils {
             input.close();
         }
     }
+
+    /**
+     * @param in the input stream
+     * @param bs a byte array to fill from the input stream
+     * @return 0 if b.length == 0 or the number or bytes really read, between 0 and b.length.
+     * If b.length != 0, a return value lower than b.length means that the end of the stream was reached.
+     * @throws IOException
+     */
+    public static int readFully(InputStream in, byte[] bs) throws IOException {
+        return IOUtils.readFully(in, bs, 0, bs.length);
+    }
+
+    /**
+     * @param in the input stream
+     * @param bs a byte array to fill from the input stream
+     * @param offset first byte to write in bs
+     * @param len number of bytes to write in bs
+     * @return 0 if b.length == 0 or the number or bytes really read, bewteen 0 and b.length.
+     * If b.length != 0, a return value lower than b.length means that the end of the stream was reached.
+     * @throws IOException
+     */
+    public static int readFully(InputStream in, byte[] bs, int offset, int len) throws IOException {
+        int byteCount = in.read(bs, offset, len);
+        if (byteCount <= -1) // length == 0 or EOF
+            return 0;
+
+        while (byteCount < len) {
+            int ret = in.read(bs, offset + byteCount, len - byteCount);
+            if (ret == -1)
+                break;
+            byteCount += ret;
+        }
+        return byteCount;
+    }
 }

--- a/src/main/java/net/iryndin/jdbf/util/JdbfUtils.java
+++ b/src/main/java/net/iryndin/jdbf/util/JdbfUtils.java
@@ -13,10 +13,11 @@ import net.iryndin.jdbf.core.DbfField;
 import net.iryndin.jdbf.core.DbfFieldTypeEnum;
 
 public class JdbfUtils {
-	
-	public static int EMPTY = 0x20;
-	public static final int FIELD_RECORD_LENGTH = 32;
-	public static final int HEADER_TERMINATOR = 0x0D;
+
+    public static final int RECORD_HEADER_LENGTH = 8;
+    public static int EMPTY = 0x20;
+    public static final int FIELD_RECORD_LENGTH = 32;
+    public static final int HEADER_TERMINATOR = 0x0D;
 
     public static final int MEMO_HEADER_LENGTH = 0x200; // 512 bytes
 

--- a/src/test/java/net/iryndin/jdbf/util/IOUtilsTest.java
+++ b/src/test/java/net/iryndin/jdbf/util/IOUtilsTest.java
@@ -1,0 +1,72 @@
+package net.iryndin.jdbf.util;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * A test class for IOUtils.
+ */
+public class IOUtilsTest {
+    private InputStream in;
+
+    @Before
+    public void setUp() {
+        byte[] bytes = new byte[10];
+        Arrays.fill(bytes, (byte) 15);
+        this.in = new ByteArrayInputStream(bytes);
+    }
+
+    @Test
+    public void readFullyAVoidArray() throws Exception {
+        byte[] bs = new byte[0];
+        Assert.assertEquals(0, IOUtils.readFully(in, bs));
+
+        byte[] ret = new byte[0];
+        Assert.assertArrayEquals(ret, bs);
+    }
+
+    @Test
+    public void readFullyASmallArray() throws Exception {
+        byte[] bs = new byte[5];
+        Assert.assertEquals(5, IOUtils.readFully(in, bs));
+
+        byte[] ret = new byte[5];
+        Arrays.fill(ret, (byte) 15);
+        Assert.assertArrayEquals(ret, bs);
+    }
+
+    @Test
+    public void readFullyAFullSizeArray() throws Exception {
+        byte[] bs = new byte[10];
+        Assert.assertEquals(10, IOUtils.readFully(in, bs));
+
+        byte[] ret = new byte[10];
+        Arrays.fill(ret, (byte) 15);
+        Assert.assertArrayEquals(ret, bs);
+    }
+
+    @Test
+    public void readFullyABigArray() throws Exception {
+        byte[] bs = new byte[100];
+        Assert.assertEquals(10, IOUtils.readFully(in, bs));
+
+        byte[] ret = new byte[100];
+        Arrays.fill(ret, 0, 10, (byte) 15);
+        Assert.assertArrayEquals(ret, bs);
+    }
+
+    @Test
+    public void readFullyWithOffsetBigArray() throws Exception {
+        byte[] bs = new byte[100];
+        Assert.assertEquals(10, IOUtils.readFully(in, bs, 5, 10));
+
+        byte[] ret = new byte[100];
+        Arrays.fill(ret, 5, 15, (byte) 15);
+        Assert.assertArrayEquals(ret, bs);
+    }
+}


### PR DESCRIPTION
From the https://github.com/iryndin/jdbf/issues/27 comment: "I recently read carefully the javadoc for InputStream (https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read(byte[]) and one can't assume that the stream has ended (end of file) if read(b) returns less than b.length bytes. The read operation on the stream can just block."
This is the fix (I hope this time it's correct).
